### PR TITLE
perf+security(contracts): GasTreasury SafeERC20 + AlkebulanCash ReentrancyGuard

### DIFF
--- a/contracts/GasTreasury.sol
+++ b/contracts/GasTreasury.sol
@@ -3,12 +3,18 @@ pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 
 /**
  * @title GasTreasury
  * @dev Collects protocol fees and forwards them to DAO treasury.
+ *      Optimized: SafeERC20 for proper token transfer checks, Address.sendValue for ETH.
  */
 contract GasTreasury is Ownable {
+
+    using SafeERC20 for IERC20;
+    using Address for address payable;
 
     address public daoTreasury;
 
@@ -19,7 +25,7 @@ contract GasTreasury is Ownable {
     constructor(address initialOwner) Ownable(initialOwner) {}
 
     /**
-     * Set DAO treasury address
+     * @dev Set DAO treasury address
      */
     function setDAOTreasury(address _daoTreasury) external onlyOwner {
         daoTreasury = _daoTreasury;
@@ -27,31 +33,37 @@ contract GasTreasury is Ownable {
     }
 
     /**
-     * Forward ERC20 tokens to DAO treasury
+     * @dev Forward all ERC20 tokens held by this contract to DAO treasury.
+     *      Uses SafeERC20 to ensure revert on failed transfer.
+     * @param token Address of the ERC20 token to forward.
+     * @return bool True if tokens were forwarded successfully.
      */
-    function forwardToken(address token) external {
-
+    function forwardToken(address token) external returns (bool) {
         require(daoTreasury != address(0), "Treasury not set");
 
         uint256 balance = IERC20(token).balanceOf(address(this));
+        if (balance == 0) return false;
 
-        IERC20(token).transfer(daoTreasury, balance);
-
+        IERC20(token).safeTransfer(daoTreasury, balance);
         emit TokensForwarded(token, balance);
+        return true;
     }
 
     /**
-     * Forward ETH to DAO treasury
+     * @dev Forward all ETH held by this contract to DAO treasury.
+     *      Uses low-level call instead of transfer() to avoid 2300 gas stipend limit.
+     * @return bool True if ETH was forwarded successfully.
      */
-    function forwardETH() external {
-
+    function forwardETH() external returns (bool) {
         require(daoTreasury != address(0), "Treasury not set");
 
         uint256 balance = address(this).balance;
+        if (balance == 0) return false;
 
-        payable(daoTreasury).transfer(balance);
-
+        // Use Address.sendValue for gas-efficient ETH forwarding (no 2300 gas limit)
+        payable(daoTreasury).sendValue(balance);
         emit EthForwarded(balance);
+        return true;
     }
 
     receive() external payable {}


### PR DESCRIPTION
## Gas Optimization + Security Fix for Issue #4

Two contracts optimized:

### GasTreasury.sol
1. **safeTransfer** — OpenZeppelin SafeERC20 properly checks return values and reverts on failure. Standard `transfer()` silently fails on some tokens (USDT, etc.).
2. **Address.sendValue** — Replaces `transfer()` for ETH forwarding. `transfer()` is capped at 2300 gas and fails for contracts with complex `receive()`/`fallback()`. `sendValue()` uses low-level `call{value: amount}()`.
3. **Early-return on zero balance** — Skips unnecessary SLOAD + external call when treasury is empty.

### AlkebulanCash.sol
1. **nonReentrant guard** — CRITICAL. `_update` makes 2 consecutive external calls (`super._update` to treasury + to recipient). Without reentrancy protection, a malicious contract could re-enter between those calls via `receive()`/`fallback()`, potentially draining fees or manipulating state.
2. **Removed redundant checks** — `from == to` (no-op) and `msg.sender == address(this)` (this contract never initiates transfers) cost gas with zero effect.

No breaking changes. New import: ReentrancyGuardUpgradeable.

— 一筒 🦀